### PR TITLE
Small Fixes to the Training Material

### DIFF
--- a/docs/python/install-python.md
+++ b/docs/python/install-python.md
@@ -77,7 +77,7 @@ correctly.
 **Required dependency**
 
 ```sh
-sudo apt-get install bzip2
+sudo apt install bzip2
 ```
 
 **Python**

--- a/docs/r/install-r.md
+++ b/docs/r/install-r.md
@@ -42,7 +42,7 @@ For data science work in production, it is important to provide code stability b
 
 This means that using your Linux package manager for installing R in production is not a good idea.
 
-!!! tip "Recommendation"
+!!! tip 
     We recommend you don't use a Linux package manager to install R.
 
 

--- a/docs/r/install-r.md
+++ b/docs/r/install-r.md
@@ -65,6 +65,7 @@ This offers maximum flexibility, because you can specify the location of the ins
 
 The downside of installing R from source is that it takes some time for the compilation to complete.
 
+If you want to learn more about `make` you can read about it here: [https://swcarpentry.github.io/make-novice/](https://swcarpentry.github.io/make-novice/)
 
 
 

--- a/docs/r/lab-install-r.md
+++ b/docs/r/lab-install-r.md
@@ -10,8 +10,8 @@ Your task is to install R (version 3.6.0) from the pre-compiled binaries, follow
 For your convenience, we repeat the instructions here.  If in doubt. follow the advice in the official documentation.
 
 ```sh
-sudo apt-get update
-sudo apt-get install gdebi-core
+sudo apt update
+sudo apt install gdebi-core
 ```
 
 Specify the R version as an environment variable:

--- a/docs/rstudio-connect/install-connect.md
+++ b/docs/rstudio-connect/install-connect.md
@@ -128,7 +128,7 @@ Upgrading R is as simple as installing another version of R side-by-side.
 
 Important: avoid upgrading by using your repository:
 
-* Avoid `apt-get upgrade` !!!
+* Avoid `apt upgrade` !!!
 * Avoid `yum upgrade` !!!
 
 

--- a/docs/rstudio-connect/lab-configure-connect.md
+++ b/docs/rstudio-connect/lab-configure-connect.md
@@ -70,7 +70,7 @@ It is possible to disable the HTTP warning.
 
 ```gcfg
 [HTTP]
-NoWarning
+NoWarning = true
 ```
 
 
@@ -106,7 +106,7 @@ For the classroom virtual machine, use these settings to edit the Connect config
 [SMTP] 
 Host = localhost
 Port = 25
-startTls = never
+StartTLS = never
 ```
 
 * Save the settings.
@@ -152,7 +152,7 @@ Hint: You can get the LDAP structure for user `jen` with:
 ldapsearch -w admin -h leader.example.org -p 389 -D cn=admin,dc=example,dc=org -b dc=example,dc=org cn=jen
 ```
 
-Hint: It is enough to adjust `ServerAddress`, `BindDN`, `BindPassword` and `UserSearchBaseDN`.
+Hint: You have to adjust `ServerAddress`, `BindDN`, `BindPassword`, `UserSearchBaseDN`, `UsernameAttribute` and `UserObjectClass`.
 
 
 ## Task: activate your license

--- a/docs/rstudio-connect/lab-configure-connect.md
+++ b/docs/rstudio-connect/lab-configure-connect.md
@@ -335,11 +335,11 @@ Address = http://ec2-00-00-00-00.us-east-2.compute.amazonaws.com/rsconnect
 [SMTP]
 Host = localhost
 Port = 25
-startTls = never
+StartTLS = never
 
 [HTTP]
 Listen = :3939
-NoWarning
+NoWarning = true
 
 [Authentication]
 Provider = LDAP

--- a/docs/rstudio-server-pro/lab-install-rsp.md
+++ b/docs/rstudio-server-pro/lab-install-rsp.md
@@ -79,7 +79,7 @@ Run the download and install script on that page.
 
 ```bash
 cd /usr/local/src
-sudo apt-get install gdebi-core
+sudo apt install gdebi-core
 curl -O https://download2.rstudio.org/server/trusty/amd64/rstudio-server-pro-1.2.5042-1-amd64.deb
 sudo gdebi rstudio-server-pro-1.2.5042-1-amd64.deb
 ```

--- a/docs/using-rstudio-package-manager/lab-using-rspm-repositories.md
+++ b/docs/using-rstudio-package-manager/lab-using-rspm-repositories.md
@@ -101,7 +101,7 @@ Hint: You can also pass in the names of packages directly instead of creating a
 list of packages, as in:
 
 ```sh
-rspm add --packages 'plumber,shiny,ISLR' --source=subset --dryrun
+rspm add --packages 'plumber,shiny,ISLR' --source=subset
 ```
 
 Hint: Re-use the transaction ID output from the `rspm add` command with

--- a/docs/using-rstudio-package-manager/lab-using-rspm-repositories.md
+++ b/docs/using-rstudio-package-manager/lab-using-rspm-repositories.md
@@ -100,12 +100,17 @@ to add a new repository that is subscribed to a source of approved CRAN packages
 Hint: You can also pass in the names of packages directly instead of creating a
 list of packages, as in:
 
+This will do a dry-run of the package installation and print a transaction ID.
+
 ```sh
 rspm add --packages 'plumber,shiny,ISLR' --source=subset
 ```
 
-Hint: Re-use the transaction ID output from the `rspm add` command with
-`--dryrun` flag.
+The transaction ID printed above is used to then apply the command with the flag `--transaction-id`.
+
+```
+rspm add --packages 'plumber,shiny,ISLR' --source=subset --transaction-id=<TRANSACTION-ID>
+```
 
 The steps you will perform are outlined as follows:
 
@@ -189,7 +194,7 @@ Navigate to the RSPM web interface in your browser and explore the newly created
 ## Task: Add a Git repository
 
 Follow the documented steps for 
-[Serving Local Packages from Git](https://docs.rstudio.com/rspm/admin/quickstarts.html#quickstart-local-git)
+[Serving Local Packages from Git](https://docs.rstudio.com/rspm/admin/quickstarts.html#quickstart-git)
 to add a new repository that is subscribed to a source with packages from Git.
 
 Hint: You'll need to configure the 


### PR DESCRIPTION
This PR addresses all of the small tasks to complete on Issue #44 including:

-  Standardizing on the use of tips & recommendations by eliminating recommendations
- Added an external link to a resource from The Carpentries about `make` and how to use it
- Replaced all instances of `apt-get` with `apt`
- For Lab 4.2, updated the Connect config file examples to the latest spellings
- For Lab 7.1, updated the CLI commands and hints to RStudio PM 1.2