### PR TITLE
Standardizing the path for the workshop materials

### DIFF
--- a/docs/rstudio-server-pro/lab-security.md
+++ b/docs/rstudio-server-pro/lab-security.md
@@ -416,7 +416,7 @@ In this part, you configure your server with `sssd`.
 
 `sssd` helps you integrate your Linux system with LDAP. The configuration template is in your workshop materials.
 
-**Important: You can find the workshop materials at `/usr/share/class/class-repo/`.**
+**Important: You can find the workshop materials at `/usr/share/class/`.**
 
 
 Tasks:
@@ -427,7 +427,7 @@ Tasks:
 ??? note "Show me how..."
 
     ```sh
-    sudo cp /usr/share/class/class-repo/s-template.txt /etc/sssd/sssd.conf
+    sudo cp /usr/share/class/s-template.txt /etc/sssd/sssd.conf
     ```
 
 
@@ -514,7 +514,7 @@ RStudio Server Pro supports PAM sessions. The PAM sessions work with `sssd` to a
 
 Tasks
 
-1. Copy the following files (**Remember:** workshop materials are under `/usr/share/class/class-repo/`.):
+1. Copy the following files (**Remember:** workshop materials are under `/usr/share/class/`.):
 
     What        | From:                  | To:
     -------     | ---------------------- | ----------------------------


### PR DESCRIPTION
This PR addresses issue #46 in terms of the course materials. A [PR](https://github.com/rstudio/training-tool-admin/pull/136) has also been open in the repository of the admin training tool so that with new VMs the path is standard. 